### PR TITLE
Add optional 'lang' config variable

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -42,8 +42,10 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
+        $lang = $this->getConfig('lang');
+        $lang = $lang ? '&lang='.$lang : '';
         $response = $this->getHttpClient()->get(
-            'https://api.vk.com/method/users.get?user_ids='.$token['user_id'].'&fields=uid,first_name,last_name,screen_name,photo'
+            'https://api.vk.com/method/users.get?user_ids='.$token['user_id'].'&fields=uid,first_name,last_name,screen_name,photo'.$lang
         );
 
         $response = json_decode($response->getBody()->getContents(), true)['response'][0];


### PR DESCRIPTION
Add optional `lang` config variable to set language when getting user data.
You can use it like so

``` php
$config = new \SocialiteProviders\Manager\Config(
  config('services.vkontakte.client_id'),
  config('services.vkontakte.client_secret'),
  config('services.vkontakte.redirect'),
  ['lang' => config('services.vkontakte.lang')]
);
$user = Socialite::with('vkontakte')->setConfig($config)->user();
```
