### PR TITLE
Enable using 'lang' param from services config

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -116,4 +116,12 @@ class Provider extends AbstractProvider implements ProviderInterface
 
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function additionalConfigKeys()
+    {
+        return ['lang'];
+    }
 }


### PR DESCRIPTION
This lang usage was too hard for me: https://github.com/SocialiteProviders/VKontakte/pull/16
 : )

With this fix you can simply use lang:

``` php
'vkontakte' => [
    'client_id' => env('SOCIAL_VK_APP_ID'),
    'client_secret' => env('SOCIAL_VK_SECRET_KEY'),
    'lang' => 'ru'
],
```

in services.php config. Before the fix lang param was ignored because it was not in the list of additional params.
