### PR TITLE
Fix VKontakte version for API requests

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -47,7 +47,7 @@ class Provider extends AbstractProvider implements ProviderInterface
         $lang = $this->getConfig('lang');
         $lang = $lang ? '&language='.$lang : '';
         $response = $this->getHttpClient()->get(
-            'https://api.vk.com/method/users.get?access_token='.$token.'&fields='.implode(',', $this->fields).$lang
+            'https://api.vk.com/method/users.get?access_token='.$token.'&fields='.implode(',', $this->fields).$lang.'&v=3.0'
         );
 
         $response = json_decode($response->getBody()->getContents(), true)['response'][0];

--- a/Provider.php
+++ b/Provider.php
@@ -20,6 +20,13 @@ class Provider extends AbstractProvider implements ProviderInterface
      * {@inheritdoc}
      */
     protected $scopes = ['email'];
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected $parameters = [
+    	'v' => '5.69',
+    ];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Fix. Version required. Compliant with Provider - VK API v. 3.0