### PR TITLE
Custom api version

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
             'access_token' => $token,
             'fields'       => implode(',', $this->fields),
             'lang'         => $this->getConfig('lang', 'en'),
-            'v'            => self::VERSION,
+            'v'            => $this->getConfig('api_version', self::VERSION),
         ]);
 
         $response = $this->getHttpClient()->get('https://api.vk.com/method/users.get?'.$params);

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 'vkontakte' => [    
   'client_id' => env('VKONTAKTE_CLIENT_ID'),  
   'client_secret' => env('VKONTAKTE_CLIENT_SECRET'),  
-  'redirect' => env('VKONTAKTE_REDIRECT_URI') 
+  'redirect' => env('VKONTAKTE_REDIRECT_URI'),
+  'api_version' => env('VKONTAKTE_API_VERSION')
 ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ You should now be able to use the provider like you would regularly use Socialit
 return Socialite::driver('vkontakte')->redirect();
 ```
 
+#### Usage with custom api version
+
+```php
+
+$config = new \SocialiteProviders\Manager\Config(
+            config('services.vkontakte.client_id'),
+            config('services.vkontakte.client_secret'),
+            config('services.vkontakte.redirect'),
+            [
+                'api_version' => config('services.vkontakte.api_version'),
+            ]
+        )
+return Socialite::driver('vkontakte')->setConfig($config)->redirect();
+
+// and some other
+$socialite = new Socialite::with('vkontakte')->setConfig($config);
+```
+
 ### Returned User fields
 
 - ``id``


### PR DESCRIPTION
1) In SocialiteProviders\VKontakte\Provider::getUserByToken() used const VERSION = '5.92';
https://vk.com/dev/constant_version_updates
I wrote to VK support. Sorry for russian language
```me
Здравствуйте.

Нигде в документации не нашёл информацию об окончании поддержки версии 5.92.

На странице https://vk.com/dev/constant_version_updates?f=2. Что .. указаны даты только для 3х версий: 5.41, 5.61, 5.81. Так же указано, что версии прекратят свое существование через 2 года после релиза, но информацию о дате релиза версии я нигде не нашёл.
К примеру, мы используем версию 5.92
На странице https://vk.com/dev.php?method=versions не указана её дата запуска.
Но судя по тому, что "С 2 сентября 2021 года прекратится поддержка версий ниже 5.81", а версия 5.103 - "в октябре 2021 года.", то 5.92 должна быть где-то по середине, но точной даты не нашёл. Для нас это очень важно для планирования работ по переходу на новое АПИ.
```
```vk support
Здравствуйте, Alexander!

Дело в том, что после отключения версии 5.81 мы можем уже следующим шагом отключить 5.101, а не 5.92. Поэтому лучше планировать на более сжатые сроки, например, на конец поддержки версии 5.81. Так вы точно не ошибетесь.

Команда поддержки ВКонтакте
```
in short:
Api version 5.92 will be discontinued around September 2nd.

OR 
2) maybe create issue with topic "change const VERSION to 5.131"?