### PR TITLE
stateless fixed default

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -20,7 +20,7 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $stateless = true;
+    protected $stateless = false;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
The current stateless property is set to true. This prevents the state option from being used, while setting stateless to false allows it to be used and throws \InvalidStateException as it should work.