### PR TITLE
feat!: Update VK API domain to vk.ru

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -24,12 +24,12 @@ class Provider extends AbstractProvider
 
     protected function getAuthUrl($state): string
     {
-        return $this->buildAuthUrlFromBase('https://oauth.vk.com/authorize', $state);
+        return $this->buildAuthUrlFromBase('https://oauth.vk.ru/authorize', $state);
     }
 
     protected function getTokenUrl(): string
     {
-        return 'https://oauth.vk.com/access_token';
+        return 'https://oauth.vk.ru/access_token';
     }
 
     /**
@@ -45,7 +45,7 @@ class Provider extends AbstractProvider
             $token = $token['access_token'];
         }
 
-        $response = $this->getHttpClient()->get('https://api.vk.com/method/users.get', [
+        $response = $this->getHttpClient()->get('https://api.vk.ru/method/users.get', [
             RequestOptions::QUERY => [
                 'access_token' => $token,
                 'fields'       => implode(',', $this->fields),

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ composer require socialiteproviders/vkontakte
 
 ## Register an application 
 
-Add new application at [vk.com](https://vk.com/editapp?act=create).
+Add new application at [vk.ru](https://vk.ru/editapp?act=create).
 
 ## Installation & Basic Usage
 
@@ -71,4 +71,4 @@ return Socialite::driver('vkontakte')->redirect();
 
 ### Reference
 
-- [Vk.com API Reference](https://vk.com/dev/methods)
+- [vk.ru API Reference](https://vk.ru/dev/methods)


### PR DESCRIPTION
Updates all VK API endpoints from vk.com to vk.ru as required by VKontakte. This is a critical change with a deadline of September 30.

https://habr.com/ru/news/943232/